### PR TITLE
Sort MediaFiles.

### DIFF
--- a/main.py
+++ b/main.py
@@ -240,7 +240,7 @@ def visit(arg, dirname, names):
     os.path.isfile(os.path.join(dirname, name))]
   count = len(mediaFiles)
   if count > 0:
-    arg[dirname] = {'files': mediaFiles}
+    arg[dirname] = {'files': sorted(mediaFiles)}
 
 def findMedia(source):
   hash = {}


### PR DESCRIPTION
Hi,

While doing upload photos, I found it doesn't upload the files in order.

It is because os.path.walk() uses os.listdir(). 
And os.listdir() returns arbitrary order of
files inside the directory. This commit sorts the MediaFiles by natural
ordering thus the files will be uploaded in the order.

Please review this patch and see if it is good. And ask me to refine it if it is not good enough.
Thank you very much,
Paul
